### PR TITLE
Updating configuration to allow CentOps integration to work for MockBot and MockClassifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is used to host integration tests and overall test artefacts tha
 
 As a developer, you may want to run the tests in this repository on your local machine. This is simple to do using Docker and Docker Compose.
 
-#### Clone repositories
+### Clone repositories
 
 In order to run the tests in this repository, please clone each of the following repositories to a working folder (for example `c:\git\buerokratt`). We'll use the reference `[working folder`] to describe this location for the rest of the guide.
 
@@ -18,33 +18,33 @@ In order to run the tests in this repository, please clone each of the following
 4. Clone the `main` branch of https://github.com/buerokratt/CentOps to  `[working folder]/CentOps`
 5. Clone the `main` branch of https://github.com/buerokratt/Tests to  `[working folder]/Tests`
 
-#### Install .net CLI
+### Install .net CLI
 
 The tests are written using .net so you need the .net CLI to run them.
 
 1. Install the .net 6.0 (or newer) CLI from [Install .NET on Windows, Linux, and macOS](https://docs.microsoft.com/en-us/dotnet/core/install/)
 
-#### Install Docker
+### Install Docker
 
 When running tests locally, you will use Docker Desktop.
 
 1. Install Docker Desktop from https://www.docker.com/products/docker-desktop/
 
-#### Docker Network Bridge
+### Docker Network Bridge
 
 In order to run the various services in containers concurrently, you will use Docker Compose. In order for the containers to be able to communicate with each other, you will create a Docker network bridge.
 
 1. Open a terminal and navigating to `[working folder]`
 2. Execute `docker network create -d bridge my-network`
 
-#### Docker Compose
+### Docker Compose
 
 To run the containers, you will need a Docker Compose file.
 
 1. Open a terminal and navigate cd to `[working folder]/Tests`
 3. Execute `docker compose up --build` to build and run the containers specified in the `docker-compose.yml` file. This has completed when you see "created" next to each of the 4 containers and you see logs in the terminal
 
-#### Run Test
+### Run Test
 
 You can run the test in a terminal or Visual Studio. These steps are for a terminal but you can get a more detailed view by running the tests in test Explorer in Visual Studio.
 
@@ -52,4 +52,4 @@ You can run the test in a terminal or Visual Studio. These steps are for a termi
 
 1. Open a terminal and navigate to `[working folder]/Tests/src/`
 2. Execute `dotnet test`
-3. If sucessful, you will see that 1 test from "Tests.IntegrationTests.dll" has "Passed!" in the terminal.
+3. If successful, you will see that 1 test from "Tests.IntegrationTests.dll" has "Passed!" in the terminal.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:80
       - DMRSERVICESETTINGS__DMRAPIURI=http://dmr/messages
+      - DMRSERVICESETTINGS__CENTOPSURI=http://centops
+      - DMRSERVICESETTINGS__CENTOPSAPIKEY=thisisareallylongkeyforclassifier
     networks:
       - my-network
 
@@ -38,6 +40,8 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:80
       - DMRSERVICESETTINGS__DMRAPIURI=http://dmr/messages
+      - DMRSERVICESETTINGS__CENTOPSURI=http://centops
+      - DMRSERVICESETTINGS__CENTOPSAPIKEY=thisisareallylongkeyformockbot1
       - BOTSETTINGS__ID=bot1
     networks:
       - my-network
@@ -52,6 +56,8 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:80
       - DMRSERVICESETTINGS__DMRAPIURI=http://dmr/messages
+      - DMRSERVICESETTINGS__CENTOPSURI=http://centops
+      - DMRSERVICESETTINGS__CENTOPSAPIKEY=thisisareallylongkeyformockbot2
       - BOTSETTINGS__ID=bot2
     networks:
       - my-network

--- a/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
+++ b/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
@@ -42,7 +42,7 @@ namespace Tests.IntegrationTests.Fixtures
                 Host = "http://classifier/dmr-api/messages",
                 Type = "Classifier",
                 Status = "Active",
-                ApiKey = "thisisareallylongkey"
+                ApiKey = "thisisareallylongkeyforclassifier"
             });
             _ = _client.Request<Participant>(Verb.Post, _participantsUri, classifierPostBody).Result;
 
@@ -66,7 +66,7 @@ namespace Tests.IntegrationTests.Fixtures
                 Host = "http://bot1/dmr-api/messages",
                 Type = "Chatbot",
                 Status = "Active",
-                ApiKey = "thisisareallylongkey"
+                ApiKey = "thisisareallylongkeyformockbot1"
             });
             _ = _client.Request<Participant>(Verb.Post, _participantsUri, bot1PostBody).Result;
         }


### PR DESCRIPTION
- I've left the previous configuration in there for now as I suppose this pipeline will still run for other commits - so in theory this should work for both the CentOps integration and without.