### PR TITLE
Adding a wait period at the beginning of the test to allow configuration to stabilise

### DIFF
--- a/src/Tests.IntegrationTests/ClassifyMessageTests.cs
+++ b/src/Tests.IntegrationTests/ClassifyMessageTests.cs
@@ -41,6 +41,9 @@ namespace Tests.IntegrationTests
         [Fact(Timeout = 4 * 60 * 1000)]
         public async Task GivenValidMessageReceivesValidResponse()
         {
+            // Allow the environment to stabilise with CentOps participant configuration.
+            await Task.Delay(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+
             _output.WriteLine($"Starting {nameof(GivenValidMessageReceivesValidResponse)}");
 
             // Arrange


### PR DESCRIPTION
- Services need time (based on their polling interval) to retrieve configuration.
- It _looks_ like the test starts before configuration has propagated.
- Adding an explicit wait before the test starts seems to have helped locally.