### PR TITLE
Adding in multiple HttpClient in Integration Tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - DMRSERVICESETTINGS__CENTOPSURI=http://centops
       - DMRSERVICESETTINGS__CENTOPSAPIKEY=thisisareallylongkeyformockbot1
       - BOTSETTINGS__ID=bot1
+      - CONNECTIONSTRINGS__APIKEY=testing
     networks:
       - my-network
 
@@ -58,6 +59,7 @@ services:
       - DMRSERVICESETTINGS__DMRAPIURI=http://dmr/messages
       - DMRSERVICESETTINGS__CENTOPSURI=http://centops
       - DMRSERVICESETTINGS__CENTOPSAPIKEY=thisisareallylongkeyformockbot2
+      - CONNECTIONSTRINGS__APIKEY=testing
       - BOTSETTINGS__ID=bot2
     networks:
       - my-network

--- a/src/Tests.IntegrationTests/ClassifyMessageTests.cs
+++ b/src/Tests.IntegrationTests/ClassifyMessageTests.cs
@@ -6,18 +6,17 @@ using Xunit.Abstractions;
 
 namespace Tests.IntegrationTests
 {
-    public sealed class ClassifyMessageTests : IClassFixture<CentOpsFixture>, IDisposable
+    public sealed class ClassifyMessageTests : IClassFixture<CentOpsFixture>
     {
         private readonly ITestOutputHelper _output;
         private readonly IConfiguration _configuration;
-        private readonly HttpClient _client;
+        private readonly TestClients _testClient;
 
-        public ClassifyMessageTests(IConfiguration configuration, ITestOutputHelper output)
+        public ClassifyMessageTests(IConfiguration configuration, ITestOutputHelper output, TestClients testClients)
         {
             _configuration = configuration;
             _output = output;
-            _client = new HttpClient();
-            _client.DefaultRequestHeaders.Add("x-api-key", _configuration["CentOpsApiKey"]);
+            _testClient = testClients;
         }
 
         [Fact(Timeout = 2 * 60 * 1000)]
@@ -28,8 +27,8 @@ namespace Tests.IntegrationTests
             var participantsUri = new Uri($"{_configuration["CentOpsUrl"]}/admin/participants");
 
             // Act
-            var participants = await _client.Request<List<Participant>>(Verb.Get, participantsUri).ConfigureAwait(false);
-            var institutions = await _client.Request<List<Institution>>(Verb.Get, institutionsUri).ConfigureAwait(false);
+            var participants = await _testClient.CentOpsAdminClient.Request<List<Participant>>(Verb.Get, participantsUri).ConfigureAwait(false);
+            var institutions = await _testClient.CentOpsAdminClient.Request<List<Institution>>(Verb.Get, institutionsUri).ConfigureAwait(false);
 
             // Assert
             _ = Assert.Single(institutions);
@@ -52,12 +51,12 @@ namespace Tests.IntegrationTests
 
             // Act
             // 1 Create Chat
-            var createdChat = await _client.Request<Chat>(Verb.Post, chatsUri, _configuration["CentOpsApiKey"]).ConfigureAwait(false);
+            var createdChat = await _testClient.MockBotChatClient.Request<Chat>(Verb.Post, chatsUri, string.Empty).ConfigureAwait(false);
             _output.WriteLine($"createdChat.Id = {createdChat.Id}");
 
             // 2 Create Message
             var chatMessageUri = new Uri($"{_configuration["Bot1Url"]}/client-api/chats/{createdChat.Id}/messages");
-            var createdChatMessage = await _client.Request<ChatMessage>(Verb.Post, chatMessageUri, "i want to register my child at school").ConfigureAwait(false);
+            var createdChatMessage = await _testClient.MockBotChatClient.Request<ChatMessage>(Verb.Post, chatMessageUri, "i want to register my child at school").ConfigureAwait(false);
             _output.WriteLine($"createdChatMessage.Id = {createdChatMessage.Id}");
 
             // 3 Retry until we have 2 messages in the chat that this test created
@@ -65,7 +64,7 @@ namespace Tests.IntegrationTests
             bool breakLoop = false;
             while (!breakLoop)
             {
-                var chats = await _client.Request<List<Chat>>(Verb.Get, chatsUri).ConfigureAwait(false);
+                var chats = await _testClient.MockBotChatClient.Request<List<Chat>>(Verb.Get, chatsUri).ConfigureAwait(false);
                 resultChat = chats.First(c => c.Id == createdChat.Id);
                 _output.WriteLine($"resultChat.Messages.Count= {resultChat.Messages.Count}");
 
@@ -88,11 +87,6 @@ namespace Tests.IntegrationTests
             Assert.Equal("CLASSIFIER", dmrMessage.SentBy.ToUpperInvariant());
             Assert.Equal("EDUCATION", dmrMessage.Classification.ToUpperInvariant());
             Assert.Equal(createdChatMessage.Content, dmrMessage.Content);
-        }
-
-        public void Dispose()
-        {
-            _client.Dispose();
         }
     }
 }

--- a/src/Tests.IntegrationTests/Startup.cs
+++ b/src/Tests.IntegrationTests/Startup.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Tests.IntegrationTests
@@ -17,6 +18,7 @@ namespace Tests.IntegrationTests
                 .AddEnvironmentVariables()
                 .Build();
 
+            _ = hostBuilder.ConfigureServices(services => services.AddSingleton<TestClients>());
             _ = hostBuilder.ConfigureHostConfiguration(builder => builder.AddConfiguration(config));
         }
     }

--- a/src/Tests.IntegrationTests/TestClients.cs
+++ b/src/Tests.IntegrationTests/TestClients.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Tests.IntegrationTests
+{
+    public class TestClients : IDisposable
+    {
+        public HttpClient CentOpsAdminClient { get; }
+
+        public HttpClient MockBotChatClient { get; }
+
+        public TestClients(IConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            CentOpsAdminClient = new HttpClient();
+            CentOpsAdminClient.DefaultRequestHeaders.Add("x-api-key", configuration["CentOpsApiKey"]);
+
+            MockBotChatClient = new HttpClient();
+            MockBotChatClient.DefaultRequestHeaders.Add("x-api-key", configuration["Bot1ApiKey"]);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                CentOpsAdminClient.Dispose();
+                MockBotChatClient.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Tests.IntegrationTests/TestClients.cs
+++ b/src/Tests.IntegrationTests/TestClients.cs
@@ -8,6 +8,8 @@ namespace Tests.IntegrationTests
 
         public HttpClient MockBotChatClient { get; }
 
+        private bool _disposed;
+
         public TestClients(IConfiguration configuration)
         {
             if (configuration == null)
@@ -24,11 +26,18 @@ namespace Tests.IntegrationTests
 
         protected virtual void Dispose(bool disposing)
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             if (disposing)
             {
                 CentOpsAdminClient.Dispose();
                 MockBotChatClient.Dispose();
             }
+
+            _disposed = true;
         }
 
         public void Dispose()

--- a/src/Tests.IntegrationTests/appsettings.json
+++ b/src/Tests.IntegrationTests/appsettings.json
@@ -1,5 +1,6 @@
 {
   "Bot1Url": "http://localhost:9012",
+  "Bot1ApiKey":  "testing",
   "CentOpsUrl": "http://localhost:9014",
   "CentOpsApiKey": "testingadmin"
 }


### PR DESCRIPTION
- I've fiddled with tests a fair bit.  I resisted the urge to bring in Refit - but I'm open to the suggestion if people agree it's worth the  effort.
- MockBot now has an API key on the Chatbot API.