### PR TITLE
Accomodate existing centops setup

### DIFF
--- a/src/Tests.IntegrationTests/ClassifyMessageTests.cs
+++ b/src/Tests.IntegrationTests/ClassifyMessageTests.cs
@@ -10,7 +10,6 @@ namespace Tests.IntegrationTests
     {
         private readonly ITestOutputHelper _output;
         private readonly IConfiguration _configuration;
-        private readonly HttpClient _client;
         private readonly CentOpsFixture _fixture;
 
         private readonly TestClients _testClient;

--- a/src/Tests.IntegrationTests/ClassifyMessageTests.cs
+++ b/src/Tests.IntegrationTests/ClassifyMessageTests.cs
@@ -32,12 +32,11 @@ namespace Tests.IntegrationTests
             // Act
             var allInstitutions = await _client.Request<List<Institution>>(Verb.Get, institutionsUri).ConfigureAwait(false);
             var allParticipants = await _client.Request<List<Participant>>(Verb.Get, participantsUri).ConfigureAwait(false);
-            var testRunInstitutions = allInstitutions.Where(p => p.Name == $"TestInstitution{_fixture.TestId}").ToList();
-            var testRunInstitution = testRunInstitutions.Single();
-            var testRunParticipants = allParticipants.Where(i => i.InstitutionId == testRunInstitution.Id).ToList();
+            var testRunInstitution = allInstitutions.FirstOrDefault(i => i.Name == _fixture.TestInstitutionName);
+            var testRunParticipants = allParticipants.Where(p => p.InstitutionId == testRunInstitution.Id).ToList();
 
             // Assert
-            _ = Assert.Single(testRunInstitutions);
+            Assert.NotNull(testRunInstitution);
             Assert.Equal(3, testRunParticipants.Count);
             Assert.Equal(testRunParticipants[0].InstitutionId, testRunInstitution.Id);
             Assert.Equal(testRunParticipants[1].InstitutionId, testRunInstitution.Id);

--- a/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
+++ b/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
@@ -13,7 +13,7 @@ namespace Tests.IntegrationTests.Fixtures
         private readonly Uri _participantsUri;
         private readonly HttpClient _client;
 
-        public string TestId { get; private set; }
+        public string TestInstitutionName { get; private set; }
 
         public CentOpsFixture(IConfiguration configuration)
         {
@@ -21,7 +21,7 @@ namespace Tests.IntegrationTests.Fixtures
 
             // Setup
             _configuration = configuration;
-            TestId = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.CurrentCulture);
+            TestInstitutionName = $"TestInstitution{DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.CurrentCulture)}";
             _client = new HttpClient();
             _client.DefaultRequestHeaders.Add("x-api-key", _configuration["CentOpsApiKey"]);
             _institutionsUri = new Uri($"{_configuration["CentOpsUrl"]}/admin/institutions");
@@ -30,7 +30,7 @@ namespace Tests.IntegrationTests.Fixtures
             // Create Institution
             var institutionPostBody = JsonSerializer.Serialize(new InstitutionRequest()
             {
-                Name = $"TestInstitution{TestId}",
+                Name = TestInstitutionName,
             });
             var institution = _client.Request<Institution>(Verb.Post, _institutionsUri, institutionPostBody).Result;
 
@@ -88,7 +88,7 @@ namespace Tests.IntegrationTests.Fixtures
 
             // Delete institution
             var institutions = _client.Request<List<Institution>>(Verb.Get, _institutionsUri).Result;
-            var testInstitution = institutions.FirstOrDefault(i => i.Name == $"TestInstitution{TestId}");
+            var testInstitution = institutions.FirstOrDefault(i => i.Name == TestInstitutionName);
             var deleteInstitutionUri = new Uri($"{_institutionsUri}/{testInstitution.Id}");
             _ = _client.Request<List<Participant>>(Verb.Delete, deleteInstitutionUri).Result;
 

--- a/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
+++ b/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
@@ -9,10 +9,11 @@ namespace Tests.IntegrationTests.Fixtures
     public sealed class CentOpsFixture : IDisposable
     {
         private readonly IConfiguration _configuration;
-        private readonly string _testId;
         private readonly Uri _institutionsUri;
         private readonly Uri _participantsUri;
         private readonly HttpClient _client;
+
+        public string TestId { get; private set; }
 
         public CentOpsFixture(IConfiguration configuration)
         {
@@ -20,7 +21,7 @@ namespace Tests.IntegrationTests.Fixtures
 
             // Setup
             _configuration = configuration;
-            _testId = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.CurrentCulture);
+            TestId = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.CurrentCulture);
             _client = new HttpClient();
             _client.DefaultRequestHeaders.Add("x-api-key", _configuration["CentOpsApiKey"]);
             _institutionsUri = new Uri($"{_configuration["CentOpsUrl"]}/admin/institutions");
@@ -29,7 +30,7 @@ namespace Tests.IntegrationTests.Fixtures
             // Create Institution
             var institutionPostBody = JsonSerializer.Serialize(new InstitutionRequest()
             {
-                Name = $"TestInstitution{_testId}",
+                Name = $"TestInstitution{TestId}",
             });
             var institution = _client.Request<Institution>(Verb.Post, _institutionsUri, institutionPostBody).Result;
 
@@ -87,7 +88,7 @@ namespace Tests.IntegrationTests.Fixtures
 
             // Delete institution
             var institutions = _client.Request<List<Institution>>(Verb.Get, _institutionsUri).Result;
-            var testInstitution = institutions.FirstOrDefault(i => i.Name == $"TestInstitution{_testId}");
+            var testInstitution = institutions.FirstOrDefault(i => i.Name == $"TestInstitution{TestId}");
             var deleteInstitutionUri = new Uri($"{_institutionsUri}/{testInstitution.Id}");
             _ = _client.Request<List<Participant>>(Verb.Delete, deleteInstitutionUri).Result;
 


### PR DESCRIPTION
This PR makes changes to the integration test to account for scenarios where CentOps is already configured and already contains Institutions and Participants.