### PR TITLE
Update integration test to work locally against azure components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+appsettings.development.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 *.user
 *.userosscache
 *.sln.docstates
-appsettings.development.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In order to target a deployed set of resources, the settings in `appsettings.jso
 
 1. Open a terminal and navigate to `[working folder]/Tests/src/`
 2. Execute `dotnet user-secrets init`
-3. Manually add equivilent secrets from the Azure-hosted components for each key/value pair in `[working folder]/Tests/src/Tests.IntegrationTests/appsettings.json` using this command `dotnet user-secrets set "setting key" "setting value"`
+3. Manually add equivalent secrets from the Azure-hosted components for each key/value pair in `[working folder]/Tests/src/Tests.IntegrationTests/appsettings.json` using this command `dotnet user-secrets set "setting key" "setting value"`
    1. As an alternative, you can open `secrets.json` for this project in a text editor and add the secrets that way. By default, `secrets.json` will be located in `%APPDATA%\Microsoft\UserSecrets\<user_secrets_id>\secrets.json` for Windows or `~/.microsoft/usersecrets/<user_secrets_id>/secrets.json` for Linux/Mac. You can find the value of `<user_secrets_id>` by opening the `[working folder]/Tests/src/Tests.IntegrationTests/Tests.IntegrationTests.csproj` in a text editor.
 
 ### 2 Run Test

--- a/README.md
+++ b/README.md
@@ -78,3 +78,17 @@ You can run the test in a terminal or Visual Studio. These steps are for a termi
 1. Open a terminal and navigate to `[working folder]/Tests/src/`
 2. Execute `dotnet test`
 3. If successful, you will see that 2 tests from "Tests.IntegrationTests.dll" has "Passed!" in the terminal.
+
+## Application settings
+
+The test requires settings in order to operate. These will either come from  `appsettings.json` file or from `secrets.json` (see Configure secrets.json). In both cases, the setting names are the same.
+
+- `Bot1Url` The external endpoint for the main Bot used in the test. 
+- `Bot1ApiKey` The API key used to call the Bot endpoint. Obtain from KeyVault for Azure.
+- `CentOpsUrl` The external endpoint for CentOps used in the test.
+- `CentOpsApiKey` The API key used to call the CentOps endpoint. Obtain from KeyVault for Azure.
+- `ClassifierInternalUrl` The internal URI for Classifier. For Docker Compose, this can be obtained from `[working folder]/Tests/docker-compose.yml`. For Azure, look in the Azure Kubernetes Service settings.
+- `DmrInternalUrl` The internal URL for DMR. For Docker Compose, this can be obtained from `[working folder]/Tests/docker-compose.yml`. For Azure, look in the Azure Kubernetes Service settings.
+- `Bot1InternalUrl` The internal URL for the main Bot. For Docker Compose, this can be obtained from `[working folder]/Tests/docker-compose.yml`. For Azure, look in the Azure Kubernetes Service settings.
+- `GenerateTestData` Boolean value used to control whether test data is created in the test fixture or not. Usually set to `true` when using Docker Compose but `false` when using Azure because Azure will already have data via the CD process.
+

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This repository is used to host integration tests and overall test artefacts tha
 
 [![Tests CI Pipeline](https://github.com/buerokratt/Tests/actions/workflows/ci-pullrequest-main.yml/badge.svg)](https://github.com/buerokratt/Tests/actions/workflows/ci-pullrequest-main.yml)
 
-## Running tests locally
+## Running tests locally with Docker Compose
 
 As a developer, you may want to run the tests in this repository on your local machine. This is simple to do using Docker and Docker Compose.
 
-### Clone repositories
+### 1 Clone repositories
 
 In order to run the tests in this repository, please clone each of the following repositories to a working folder (for example `c:\git\buerokratt`). We'll use the reference `[working folder`] to describe this location for the rest of the guide.
 
@@ -18,31 +18,56 @@ In order to run the tests in this repository, please clone each of the following
 4. Clone the `main` branch of https://github.com/buerokratt/CentOps to  `[working folder]/CentOps`
 5. Clone the `main` branch of https://github.com/buerokratt/Tests to  `[working folder]/Tests`
 
-### Install .net CLI
+### 2 Install .net CLI
 
 The tests are written using .net so you need the .net CLI to run them.
 
 1. Install the .net 6.0 (or newer) CLI from [Install .NET on Windows, Linux, and macOS](https://docs.microsoft.com/en-us/dotnet/core/install/)
 
-### Install Docker
+### 3 Install Docker
 
 When running tests locally, you will use Docker Desktop.
 
 1. Install Docker Desktop from https://www.docker.com/products/docker-desktop/
 
-### Docker Network Bridge
+### 4 Docker Network Bridge
 
 In order to run the various services in containers concurrently, you will use Docker Compose. In order for the containers to be able to communicate with each other, you will create a Docker network bridge.
 
 1. Open a terminal and navigating to `[working folder]`
 2. Execute `docker network create -d bridge my-network`
 
-### Docker Compose
+### 5 Docker Compose
 
 To run the containers, you will need a Docker Compose file.
 
 1. Open a terminal and navigate cd to `[working folder]/Tests`
 3. Execute `docker compose up --build` to build and run the containers specified in the `docker-compose.yml` file. This has completed when you see "created" next to each of the 4 containers and you see logs in the terminal
+
+### 6 Run Test
+
+You can run the test in a terminal or Visual Studio. These steps are for a terminal but you can get a more detailed view by running the tests in test Explorer in Visual Studio.
+
+> The test will use the version of the code which is on your local device for each repository/container. Generally, you'll want to make sure you have pulled the latest changes on the `main` branch before running the test, although there may be scenarios where you want to test from other branches.
+
+1. Open a terminal and navigate to `[working folder]/Tests/src/`
+2. Execute `dotnet test`
+3. If successful, you will see that 2 tests from "Tests.IntegrationTests.dll" has "Passed!" in the terminal.
+
+## Running tests locally against Azure hosted environment
+
+You may want to run this test against deployed component in Azure. This can be usefull to make sure that the deployed components have the correct settings and can communicate correctly.
+
+In order to do this follow steps 1 and 2 from Running tests locally with Docker Compose and then follow these steps:
+
+### Configure secrets.json
+
+In order to target a deployed set of resources, the settings in `appsettings.json` need to be over-written with values that corespond to the deployed components. It is not good practice to edit `appsettings.json` because that file is under source control and you may inadvertently commit secrets to Git. Instead you can use .net user secrets to create a local secrets.json which over-rides the settings in `appsettings.json`. See https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-6.0
+
+1. Open a terminal and navigate to `[working folder]/Tests/src/`
+2. Execute `dotnet user-secrets init`
+3. Manually add equivilent secrets from the Azure-hosted components for each key/value pair in `[working folder]/Tests/src/Tests.IntegrationTests/appsettings.json` using this command `dotnet user-secrets set "setting key" "setting value"`
+   1. As an alternative, you can open `secrets.json` for this project in a text editor and add the secrets that way. By default, `secrets.json` will be located in `%APPDATA%\Microsoft\UserSecrets\<user_secrets_id>\secrets.json` for Windows or `~/.microsoft/usersecrets/<user_secrets_id>/secrets.json` for Linux/Mac. You can find the value of `<user_secrets_id>` by opening the `[working folder]/Tests/src/Tests.IntegrationTests/Tests.IntegrationTests.csproj` in a text editor.
 
 ### Run Test
 
@@ -52,4 +77,4 @@ You can run the test in a terminal or Visual Studio. These steps are for a termi
 
 1. Open a terminal and navigate to `[working folder]/Tests/src/`
 2. Execute `dotnet test`
-3. If successful, you will see that 1 test from "Tests.IntegrationTests.dll" has "Passed!" in the terminal.
+3. If successful, you will see that 2 tests from "Tests.IntegrationTests.dll" has "Passed!" in the terminal.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ In order to do this follow steps 1 and 2 from Running tests locally with Docker 
 
 ### 1 Configure secrets.json
 
-In order to target a deployed set of resources, the settings in `appsettings.json` need to be over-written with values that corespond to the deployed components. It is not good practice to edit `appsettings.json` because that file is under source control and you may inadvertently commit secrets to Git. Instead you can use .net user secrets to create a local secrets.json which over-rides the settings in `appsettings.json`. See https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-6.0
+In order to target a deployed set of resources, the settings in `appsettings.json` need to be over-written with values that correspond to the deployed components. It is not good practice to edit `appsettings.json` because that file is under source control and you may inadvertently commit secrets to Git. Instead you can use .net user secrets to create a local secrets.json which over-rides the settings in `appsettings.json`. See https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-6.0
 
 1. Open a terminal and navigate to `[working folder]/Tests/src/`
 2. Execute `dotnet user-secrets init`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ When running tests locally, you will use Docker Desktop.
 
 ### 4 Docker Network Bridge
 
-In order to run the various services in containers concurrently, you will use Docker Compose. In order for the containers to be able to communicate with each other, you will create a Docker network bridge.
+In order to run the various services in containers concurrently, you will use Docker Compose. In order for the containers to be able to communicate with each other, you will need to create a Docker network bridge.
 
 1. Open a terminal and navigating to `[working folder]`
 2. Execute `docker network create -d bridge my-network`
@@ -60,7 +60,7 @@ You may want to run this test against deployed component in Azure. This can be u
 
 In order to do this follow steps 1 and 2 from Running tests locally with Docker Compose and then follow these steps:
 
-### Configure secrets.json
+### 1 Configure secrets.json
 
 In order to target a deployed set of resources, the settings in `appsettings.json` need to be over-written with values that corespond to the deployed components. It is not good practice to edit `appsettings.json` because that file is under source control and you may inadvertently commit secrets to Git. Instead you can use .net user secrets to create a local secrets.json which over-rides the settings in `appsettings.json`. See https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-6.0
 
@@ -69,7 +69,7 @@ In order to target a deployed set of resources, the settings in `appsettings.jso
 3. Manually add equivilent secrets from the Azure-hosted components for each key/value pair in `[working folder]/Tests/src/Tests.IntegrationTests/appsettings.json` using this command `dotnet user-secrets set "setting key" "setting value"`
    1. As an alternative, you can open `secrets.json` for this project in a text editor and add the secrets that way. By default, `secrets.json` will be located in `%APPDATA%\Microsoft\UserSecrets\<user_secrets_id>\secrets.json` for Windows or `~/.microsoft/usersecrets/<user_secrets_id>/secrets.json` for Linux/Mac. You can find the value of `<user_secrets_id>` by opening the `[working folder]/Tests/src/Tests.IntegrationTests/Tests.IntegrationTests.csproj` in a text editor.
 
-### Run Test
+### 2 Run Test
 
 You can run the test in a terminal or Visual Studio. These steps are for a terminal but you can get a more detailed view by running the tests in test Explorer in Visual Studio.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can run the test in a terminal or Visual Studio. These steps are for a termi
 
 ## Running tests locally against Azure hosted environment
 
-You may want to run this test against deployed component in Azure. This can be usefull to make sure that the deployed components have the correct settings and can communicate correctly.
+You may want to run this test against deployed component in Azure. This can be useful to make sure that the deployed components have the correct settings and can communicate correctly.
 
 In order to do this follow steps 1 and 2 from Running tests locally with Docker Compose and then follow these steps:
 

--- a/src/Tests.IntegrationTests/ClassifyMessageTests.cs
+++ b/src/Tests.IntegrationTests/ClassifyMessageTests.cs
@@ -42,7 +42,7 @@ namespace Tests.IntegrationTests
             Assert.Equal(testRunParticipants[1].InstitutionId, testRunInstitution.Id);
         }
 
-        [Fact(Timeout = 4 * 60 * 1000)]
+        [Fact(Timeout = 2 * 60 * 1000)]
         public async Task GivenValidMessageReceivesValidResponse()
         {
             // Allow the environment to stabilise with CentOps participant configuration.

--- a/src/Tests.IntegrationTests/ClassifyMessageTests.cs
+++ b/src/Tests.IntegrationTests/ClassifyMessageTests.cs
@@ -1,29 +1,33 @@
 using Microsoft.Extensions.Configuration;
-//using Tests.IntegrationTests.Fixtures;
+using Tests.IntegrationTests.Fixtures;
 using Tests.IntegrationTests.Models;
 using Tests.IntegrationTests.Extensions;
 using Xunit.Abstractions;
+using System.Globalization;
 
 namespace Tests.IntegrationTests
 {
-    //public sealed class ClassifyMessageTests : IClassFixture<CentOpsFixture>
-    public sealed class ClassifyMessageTests
+    public sealed class ClassifyMessageTests : IClassFixture<CentOpsFixture>
     {
         private readonly ITestOutputHelper _output;
         private readonly IConfiguration _configuration;
-        //private readonly CentOpsFixture _fixture;
         private readonly string _testInstitutionName;
 
         private readonly TestClients _testClient;
 
-        //public ClassifyMessageTests(IConfiguration configuration, ITestOutputHelper output, TestClients testClients, CentOpsFixture fixture)
-        public ClassifyMessageTests(IConfiguration configuration, ITestOutputHelper output, TestClients testClients)
+        public ClassifyMessageTests(IConfiguration configuration, ITestOutputHelper output, TestClients testClients, CentOpsFixture fixture)
         {
             _configuration = configuration;
             _output = output;
             _testClient = testClients;
-            //_fixture = fixture;
-            _testInstitutionName = "mock-institution";
+
+            if (fixture == null)
+            {
+                throw new ArgumentNullException(nameof(fixture));
+            }
+
+            var useFixture = Convert.ToBoolean(_configuration["UseFixture"], CultureInfo.CurrentCulture);
+            _testInstitutionName = useFixture ? fixture.TestInstitutionName : "mock-institution";
         }
 
         [Fact(Timeout = 2 * 60 * 1000)]

--- a/src/Tests.IntegrationTests/ClassifyMessageTests.cs
+++ b/src/Tests.IntegrationTests/ClassifyMessageTests.cs
@@ -1,25 +1,29 @@
 using Microsoft.Extensions.Configuration;
-using Tests.IntegrationTests.Fixtures;
+//using Tests.IntegrationTests.Fixtures;
 using Tests.IntegrationTests.Models;
 using Tests.IntegrationTests.Extensions;
 using Xunit.Abstractions;
 
 namespace Tests.IntegrationTests
 {
-    public sealed class ClassifyMessageTests : IClassFixture<CentOpsFixture>
+    //public sealed class ClassifyMessageTests : IClassFixture<CentOpsFixture>
+    public sealed class ClassifyMessageTests
     {
         private readonly ITestOutputHelper _output;
         private readonly IConfiguration _configuration;
-        private readonly CentOpsFixture _fixture;
+        //private readonly CentOpsFixture _fixture;
+        private readonly string _testInstitutionName;
 
         private readonly TestClients _testClient;
 
-        public ClassifyMessageTests(IConfiguration configuration, ITestOutputHelper output, TestClients testClients, CentOpsFixture fixture)
+        //public ClassifyMessageTests(IConfiguration configuration, ITestOutputHelper output, TestClients testClients, CentOpsFixture fixture)
+        public ClassifyMessageTests(IConfiguration configuration, ITestOutputHelper output, TestClients testClients)
         {
             _configuration = configuration;
             _output = output;
             _testClient = testClients;
-            _fixture = fixture;
+            //_fixture = fixture;
+            _testInstitutionName = "mock-institution";
         }
 
         [Fact(Timeout = 2 * 60 * 1000)]
@@ -32,7 +36,7 @@ namespace Tests.IntegrationTests
             // Act
             var allInstitutions = await _testClient.CentOpsAdminClient.Request<List<Institution>>(Verb.Get, institutionsUri).ConfigureAwait(false);
             var allParticipants = await _testClient.CentOpsAdminClient.Request<List<Participant>>(Verb.Get, participantsUri).ConfigureAwait(false);
-            var testRunInstitution = allInstitutions.FirstOrDefault(i => i.Name == _fixture.TestInstitutionName);
+            var testRunInstitution = allInstitutions.FirstOrDefault(i => i.Name == _testInstitutionName);
             var testRunParticipants = allParticipants.Where(p => p.InstitutionId == testRunInstitution.Id).ToList();
 
             // Assert

--- a/src/Tests.IntegrationTests/ClassifyMessageTests.cs
+++ b/src/Tests.IntegrationTests/ClassifyMessageTests.cs
@@ -3,7 +3,6 @@ using Tests.IntegrationTests.Fixtures;
 using Tests.IntegrationTests.Models;
 using Tests.IntegrationTests.Extensions;
 using Xunit.Abstractions;
-using System.Globalization;
 
 namespace Tests.IntegrationTests
 {
@@ -11,7 +10,7 @@ namespace Tests.IntegrationTests
     {
         private readonly ITestOutputHelper _output;
         private readonly IConfiguration _configuration;
-        private readonly string _testInstitutionName;
+        private readonly CentOpsFixture _fixture;
 
         private readonly TestClients _testClient;
 
@@ -20,14 +19,7 @@ namespace Tests.IntegrationTests
             _configuration = configuration;
             _output = output;
             _testClient = testClients;
-
-            if (fixture == null)
-            {
-                throw new ArgumentNullException(nameof(fixture));
-            }
-
-            var useFixture = Convert.ToBoolean(_configuration["UseFixture"], CultureInfo.CurrentCulture);
-            _testInstitutionName = useFixture ? fixture.TestInstitutionName : "mock-institution";
+            _fixture = fixture;
         }
 
         [Fact(Timeout = 2 * 60 * 1000)]
@@ -40,7 +32,7 @@ namespace Tests.IntegrationTests
             // Act
             var allInstitutions = await _testClient.CentOpsAdminClient.Request<List<Institution>>(Verb.Get, institutionsUri).ConfigureAwait(false);
             var allParticipants = await _testClient.CentOpsAdminClient.Request<List<Participant>>(Verb.Get, participantsUri).ConfigureAwait(false);
-            var testRunInstitution = allInstitutions.FirstOrDefault(i => i.Name == _testInstitutionName);
+            var testRunInstitution = allInstitutions.FirstOrDefault(i => i.Name == _fixture.TestInstitutionName);
             var testRunParticipants = allParticipants.Where(p => p.InstitutionId == testRunInstitution.Id).ToList();
 
             // Assert

--- a/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
+++ b/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
@@ -12,7 +12,7 @@ namespace Tests.IntegrationTests.Fixtures
         private readonly Uri _institutionsUri;
         private readonly Uri _participantsUri;
         private readonly TestClients _testClients;
-        private readonly bool _useFixture;
+        private readonly bool _generateTestData;
 
         public string TestInstitutionName { get; private set; }
 
@@ -22,9 +22,9 @@ namespace Tests.IntegrationTests.Fixtures
 
             // Setup
             _configuration = configuration;
-            _useFixture = Convert.ToBoolean(_configuration["UseFixture"], CultureInfo.InvariantCulture);
+            _generateTestData = Convert.ToBoolean(_configuration["GenerateTestData"], CultureInfo.InvariantCulture);
 
-            if (_useFixture)
+            if (_generateTestData)
             {
                 var uniqueTestId = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
                 TestInstitutionName = $"TestInstitution{uniqueTestId}";
@@ -87,7 +87,7 @@ namespace Tests.IntegrationTests.Fixtures
         {
             // Do "global" teardown here; Only called once.
 
-            if (_useFixture)
+            if (_generateTestData)
             {
                 // Get details
                 var institutions = _testClients.CentOpsAdminClient.Request<List<Institution>>(Verb.Get, _institutionsUri).Result;

--- a/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
+++ b/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
@@ -22,11 +22,11 @@ namespace Tests.IntegrationTests.Fixtures
 
             // Setup
             _configuration = configuration;
-            _useFixture = Convert.ToBoolean(_configuration["UseFixture"], CultureInfo.CurrentCulture);
+            _useFixture = Convert.ToBoolean(_configuration["UseFixture"], CultureInfo.InvariantCulture);
 
             if (_useFixture)
             {
-                var uniqueTestId = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.CurrentCulture);
+                var uniqueTestId = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
                 TestInstitutionName = $"TestInstitution{uniqueTestId}";
                 _institutionsUri = new Uri($"{_configuration["CentOpsUrl"]}/admin/institutions");
                 _participantsUri = new Uri($"{_configuration["CentOpsUrl"]}/admin/participants");

--- a/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
+++ b/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
@@ -12,6 +12,7 @@ namespace Tests.IntegrationTests.Fixtures
         private readonly Uri _institutionsUri;
         private readonly Uri _participantsUri;
         private readonly TestClients _testClients;
+        private readonly bool _useFixture;
 
         public string TestInstitutionName { get; private set; }
 
@@ -21,80 +22,88 @@ namespace Tests.IntegrationTests.Fixtures
 
             // Setup
             _configuration = configuration;
-            var uniqueTestId = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.CurrentCulture);
-            TestInstitutionName = $"TestInstitution{uniqueTestId}";
-            _institutionsUri = new Uri($"{_configuration["CentOpsUrl"]}/admin/institutions");
-            _participantsUri = new Uri($"{_configuration["CentOpsUrl"]}/admin/participants");
-            _testClients = testClients;
+            _useFixture = Convert.ToBoolean(_configuration["UseFixture"], CultureInfo.CurrentCulture);
 
-            // Create Institution
-            var institutionPostBody = JsonSerializer.Serialize(new InstitutionRequest()
+            if (_useFixture)
             {
-                Name = TestInstitutionName,
-                Status = "Active",
-            });
-            var institution = _testClients.CentOpsAdminClient.Request<Institution>(Verb.Post, _institutionsUri, institutionPostBody).Result;
+                var uniqueTestId = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.CurrentCulture);
+                TestInstitutionName = $"TestInstitution{uniqueTestId}";
+                _institutionsUri = new Uri($"{_configuration["CentOpsUrl"]}/admin/institutions");
+                _participantsUri = new Uri($"{_configuration["CentOpsUrl"]}/admin/participants");
+                _testClients = testClients;
+
+                // Create Institution
+                var institutionPostBody = JsonSerializer.Serialize(new InstitutionRequest()
+                {
+                    Name = TestInstitutionName,
+                    Status = "Active",
+                });
+                var institution = _testClients.CentOpsAdminClient.Request<Institution>(Verb.Post, _institutionsUri, institutionPostBody).Result;
 
 
-            // Create Classifier
-            var classifierPostBody = JsonSerializer.Serialize(new Participant()
-            {
-                Name = $"classifier1",
-                InstitutionId = institution.Id,
-                Host = $"{_configuration["ClassifierInternalUrl"]}/dmr-api/messages",
-                Type = "Classifier",
-                Status = "Active",
-                ApiKey = "thisisareallylongkeyforclassifier"
-            });
-            _ = _testClients.CentOpsAdminClient.Request<Participant>(Verb.Post, _participantsUri, classifierPostBody).Result;
+                // Create Classifier
+                var classifierPostBody = JsonSerializer.Serialize(new Participant()
+                {
+                    Name = $"classifier1",
+                    InstitutionId = institution.Id,
+                    Host = $"{_configuration["ClassifierInternalUrl"]}/dmr-api/messages",
+                    Type = "Classifier",
+                    Status = "Active",
+                    ApiKey = "thisisareallylongkeyforclassifier"
+                });
+                _ = _testClients.CentOpsAdminClient.Request<Participant>(Verb.Post, _participantsUri, classifierPostBody).Result;
 
-            // Create Dmr
-            var dmrPostBody = JsonSerializer.Serialize(new Participant()
-            {
-                Name = $"dmr1",
-                InstitutionId = institution.Id,
-                Host = $"{_configuration["DmrInternalUrl"]}/messages",
-                Type = "Dmr",
-                Status = "Active",
-                ApiKey = "thisisareallylongkey"
-            });
-            _ = _testClients.CentOpsAdminClient.Request<Participant>(Verb.Post, _participantsUri, dmrPostBody).Result;
+                // Create Dmr
+                var dmrPostBody = JsonSerializer.Serialize(new Participant()
+                {
+                    Name = $"dmr1",
+                    InstitutionId = institution.Id,
+                    Host = $"{_configuration["DmrInternalUrl"]}/messages",
+                    Type = "Dmr",
+                    Status = "Active",
+                    ApiKey = "thisisareallylongkey"
+                });
+                _ = _testClients.CentOpsAdminClient.Request<Participant>(Verb.Post, _participantsUri, dmrPostBody).Result;
 
-            // Create Bot1
-            var bot1PostBody = JsonSerializer.Serialize(new Participant()
-            {
-                Name = $"bot1",
-                InstitutionId = institution.Id,
-                Host = $"{_configuration["Bot1InternalUrl"]}/dmr-api/messages",
-                Type = "Chatbot",
-                Status = "Active",
-                ApiKey = "thisisareallylongkeyformockbot1"
-            });
-            _ = _testClients.CentOpsAdminClient.Request<Participant>(Verb.Post, _participantsUri, bot1PostBody).Result;
+                // Create Bot1
+                var bot1PostBody = JsonSerializer.Serialize(new Participant()
+                {
+                    Name = $"bot1",
+                    InstitutionId = institution.Id,
+                    Host = $"{_configuration["Bot1InternalUrl"]}/dmr-api/messages",
+                    Type = "Chatbot",
+                    Status = "Active",
+                    ApiKey = "thisisareallylongkeyformockbot1"
+                });
+                _ = _testClients.CentOpsAdminClient.Request<Participant>(Verb.Post, _participantsUri, bot1PostBody).Result;
+            }
         }
 
         public void Dispose()
         {
             // Do "global" teardown here; Only called once.
 
-            // Get details
-            var institutions = _testClients.CentOpsAdminClient.Request<List<Institution>>(Verb.Get, _institutionsUri).Result;
-            var testInstitution = institutions.FirstOrDefault(i => i.Name == TestInstitutionName);
-
-            // Get all participant for test id
-            var participants = _testClients.CentOpsAdminClient.Request<List<Participant>>(Verb.Get, _participantsUri).Result;
-            var testParticipants = participants.Where(p => p.InstitutionId == testInstitution.Id);
-
-            // Delete each participant
-            foreach (var testParticipant in testParticipants)
+            if (_useFixture)
             {
-                var deleteTestParticipantUri = new Uri($"{_participantsUri}/{testParticipant.Id}");
-                _ = _testClients.CentOpsAdminClient.Request<List<Participant>>(Verb.Delete, deleteTestParticipantUri).Result;
-            }
+                // Get details
+                var institutions = _testClients.CentOpsAdminClient.Request<List<Institution>>(Verb.Get, _institutionsUri).Result;
+                var testInstitution = institutions.FirstOrDefault(i => i.Name == TestInstitutionName);
 
-            // Delete institution
-            var deleteInstitutionUri = new Uri($"{_institutionsUri}/{testInstitution.Id}");
-            _ = _testClients.CentOpsAdminClient.Request<List<Participant>>(Verb.Delete, deleteInstitutionUri).Result;
+                // Get all participant for test id
+                var participants = _testClients.CentOpsAdminClient.Request<List<Participant>>(Verb.Get, _participantsUri).Result;
+                var testParticipants = participants.Where(p => p.InstitutionId == testInstitution.Id);
+
+                // Delete each participant
+                foreach (var testParticipant in testParticipants)
+                {
+                    var deleteTestParticipantUri = new Uri($"{_participantsUri}/{testParticipant.Id}");
+                    _ = _testClients.CentOpsAdminClient.Request<List<Participant>>(Verb.Delete, deleteTestParticipantUri).Result;
+                }
+
+                // Delete institution
+                var deleteInstitutionUri = new Uri($"{_institutionsUri}/{testInstitution.Id}");
+                _ = _testClients.CentOpsAdminClient.Request<List<Participant>>(Verb.Delete, deleteInstitutionUri).Result;
+            }
         }
     }
 }

--- a/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
+++ b/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
@@ -77,6 +77,10 @@ namespace Tests.IntegrationTests.Fixtures
                 });
                 _ = _testClients.CentOpsAdminClient.Request<Participant>(Verb.Post, _participantsUri, bot1PostBody).Result;
             }
+            else
+            {
+                TestInstitutionName = "mock-institution";
+            }
         }
 
         public void Dispose()

--- a/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
+++ b/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
@@ -77,19 +77,22 @@ namespace Tests.IntegrationTests.Fixtures
         {
             // Do "global" teardown here; Only called once.
 
+            // Get details
+            var institutions = _testClients.CentOpsAdminClient.Request<List<Institution>>(Verb.Get, _institutionsUri).Result;
+            var testInstitution = institutions.FirstOrDefault(i => i.Name == TestInstitutionName);
+
             // Get all participant for test id
             var participants = _testClients.CentOpsAdminClient.Request<List<Participant>>(Verb.Get, _participantsUri).Result;
+            var testParticipants = participants.Where(p => p.InstitutionId == testInstitution.Id);
 
             // Delete each participant
-            foreach (var participant in participants)
+            foreach (var testParticipant in testParticipants)
             {
-                var deleteParticipantUri = new Uri($"{_participantsUri}/{participant.Id}");
-                _ = _testClients.CentOpsAdminClient.Request<List<Participant>>(Verb.Delete, deleteParticipantUri).Result;
+                var deleteTestParticipantUri = new Uri($"{_participantsUri}/{testParticipant.Id}");
+                _ = _testClients.CentOpsAdminClient.Request<List<Participant>>(Verb.Delete, deleteTestParticipantUri).Result;
             }
 
             // Delete institution
-            var institutions = _testClients.CentOpsAdminClient.Request<List<Institution>>(Verb.Get, _institutionsUri).Result;
-            var testInstitution = institutions.FirstOrDefault(i => i.Name == TestInstitutionName);
             var deleteInstitutionUri = new Uri($"{_institutionsUri}/{testInstitution.Id}");
             _ = _testClients.CentOpsAdminClient.Request<List<Participant>>(Verb.Delete, deleteInstitutionUri).Result;
         }

--- a/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
+++ b/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
@@ -21,7 +21,8 @@ namespace Tests.IntegrationTests.Fixtures
 
             // Setup
             _configuration = configuration;
-            TestInstitutionName = $"TestInstitution{DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.CurrentCulture)}";
+            var uniqueTestId = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.CurrentCulture);
+            TestInstitutionName = $"TestInstitution{uniqueTestId}";
             _institutionsUri = new Uri($"{_configuration["CentOpsUrl"]}/admin/institutions");
             _participantsUri = new Uri($"{_configuration["CentOpsUrl"]}/admin/participants");
             _testClients = testClients;
@@ -30,6 +31,7 @@ namespace Tests.IntegrationTests.Fixtures
             var institutionPostBody = JsonSerializer.Serialize(new InstitutionRequest()
             {
                 Name = TestInstitutionName,
+                Status = "Active",
             });
             var institution = _testClients.CentOpsAdminClient.Request<Institution>(Verb.Post, _institutionsUri, institutionPostBody).Result;
 
@@ -37,9 +39,9 @@ namespace Tests.IntegrationTests.Fixtures
             // Create Classifier
             var classifierPostBody = JsonSerializer.Serialize(new Participant()
             {
-                Name = "classifier1",
+                Name = $"classifier1{uniqueTestId}",
                 InstitutionId = institution.Id,
-                Host = "http://classifier/dmr-api/messages",
+                Host = $"{_configuration["ClassifierUrl"]}/dmr-api/messages",
                 Type = "Classifier",
                 Status = "Active",
                 ApiKey = "thisisareallylongkeyforclassifier"
@@ -49,9 +51,9 @@ namespace Tests.IntegrationTests.Fixtures
             // Create Dmr
             var dmrPostBody = JsonSerializer.Serialize(new Participant()
             {
-                Name = "dmr1",
+                Name = $"dmr1{uniqueTestId}",
                 InstitutionId = institution.Id,
-                Host = "http://dmr/messages",
+                Host = $"{_configuration["DmrUrl"]}/messages",
                 Type = "Dmr",
                 Status = "Active",
                 ApiKey = "thisisareallylongkey"
@@ -61,9 +63,9 @@ namespace Tests.IntegrationTests.Fixtures
             // Create Bot1
             var bot1PostBody = JsonSerializer.Serialize(new Participant()
             {
-                Name = "bot1",
+                Name = $"bot1{uniqueTestId}",
                 InstitutionId = institution.Id,
-                Host = "http://bot1/dmr-api/messages",
+                Host = $"{_configuration["Bot1Url"]}/dmr-api/messages",
                 Type = "Chatbot",
                 Status = "Active",
                 ApiKey = "thisisareallylongkeyformockbot1"

--- a/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
+++ b/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
@@ -24,7 +24,11 @@ namespace Tests.IntegrationTests.Fixtures
             _configuration = configuration;
             _generateTestData = Convert.ToBoolean(_configuration["GenerateTestData"], CultureInfo.InvariantCulture);
 
-            if (_generateTestData)
+            if (!_generateTestData)
+            {
+                TestInstitutionName = "mock-institution";
+            }
+            else
             {
                 var uniqueTestId = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
                 TestInstitutionName = $"TestInstitution{uniqueTestId}";
@@ -76,10 +80,6 @@ namespace Tests.IntegrationTests.Fixtures
                     ApiKey = "thisisareallylongkeyformockbot1"
                 });
                 _ = _testClients.CentOpsAdminClient.Request<Participant>(Verb.Post, _participantsUri, bot1PostBody).Result;
-            }
-            else
-            {
-                TestInstitutionName = "mock-institution";
             }
         }
 

--- a/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
+++ b/src/Tests.IntegrationTests/Fixtures/CentOpsFixture.cs
@@ -39,9 +39,9 @@ namespace Tests.IntegrationTests.Fixtures
             // Create Classifier
             var classifierPostBody = JsonSerializer.Serialize(new Participant()
             {
-                Name = $"classifier1{uniqueTestId}",
+                Name = $"classifier1",
                 InstitutionId = institution.Id,
-                Host = $"{_configuration["ClassifierUrl"]}/dmr-api/messages",
+                Host = $"{_configuration["ClassifierInternalUrl"]}/dmr-api/messages",
                 Type = "Classifier",
                 Status = "Active",
                 ApiKey = "thisisareallylongkeyforclassifier"
@@ -51,9 +51,9 @@ namespace Tests.IntegrationTests.Fixtures
             // Create Dmr
             var dmrPostBody = JsonSerializer.Serialize(new Participant()
             {
-                Name = $"dmr1{uniqueTestId}",
+                Name = $"dmr1",
                 InstitutionId = institution.Id,
-                Host = $"{_configuration["DmrUrl"]}/messages",
+                Host = $"{_configuration["DmrInternalUrl"]}/messages",
                 Type = "Dmr",
                 Status = "Active",
                 ApiKey = "thisisareallylongkey"
@@ -63,9 +63,9 @@ namespace Tests.IntegrationTests.Fixtures
             // Create Bot1
             var bot1PostBody = JsonSerializer.Serialize(new Participant()
             {
-                Name = $"bot1{uniqueTestId}",
+                Name = $"bot1",
                 InstitutionId = institution.Id,
-                Host = $"{_configuration["Bot1Url"]}/dmr-api/messages",
+                Host = $"{_configuration["Bot1InternalUrl"]}/dmr-api/messages",
                 Type = "Chatbot",
                 Status = "Active",
                 ApiKey = "thisisareallylongkeyformockbot1"

--- a/src/Tests.IntegrationTests/Models/InstitutionRequest.cs
+++ b/src/Tests.IntegrationTests/Models/InstitutionRequest.cs
@@ -6,6 +6,9 @@ namespace Tests.IntegrationTests.Models
     {
         [JsonPropertyName("name")]
         public string Name { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
     }
 }
 

--- a/src/Tests.IntegrationTests/Startup.cs
+++ b/src/Tests.IntegrationTests/Startup.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -14,8 +15,9 @@ namespace Tests.IntegrationTests
             }
 
             var config = new ConfigurationBuilder()
-                .AddJsonFile(@"appsettings.json", false, false)
+                .AddJsonFile(@"appsettings.json", false, true)
                 .AddEnvironmentVariables()
+                .AddUserSecrets(Assembly.GetExecutingAssembly())
                 .Build();
 
             _ = hostBuilder.ConfigureServices(services => services.AddSingleton<TestClients>());

--- a/src/Tests.IntegrationTests/Tests.IntegrationTests.csproj
+++ b/src/Tests.IntegrationTests/Tests.IntegrationTests.csproj
@@ -43,6 +43,9 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="appsettings %28copy%29.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests.IntegrationTests/Tests.IntegrationTests.csproj
+++ b/src/Tests.IntegrationTests/Tests.IntegrationTests.csproj
@@ -10,6 +10,7 @@
     <AnalysisLevel>latest-All</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <UserSecretsId>77cd5319-5e32-4e69-92f7-b38be27818d0</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,11 +34,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>
     <None Remove="Fixtures\" />
     <None Remove="Extensions\" />
+    <None Remove="Microsoft.Extensions.Configuration.UserSecrets" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/src/Tests.IntegrationTests/Tests.IntegrationTests.csproj
+++ b/src/Tests.IntegrationTests/Tests.IntegrationTests.csproj
@@ -46,9 +46,6 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="appsettings %28copy%29.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests.IntegrationTests/appsettings.json
+++ b/src/Tests.IntegrationTests/appsettings.json
@@ -5,7 +5,8 @@
   "CentOpsApiKey": "testingadmin",
   "ClassifierInternalUrl": "http://classifier",
   "DmrInternalUrl": "http://dmr",
-  "Bot1InternalUrl": "http://bot1"
+  "Bot1InternalUrl": "http://bot1",
+  "UseFixture": "true"
 }
 //Do not change these values.
 //Use `dotnet user-secrets init` to initialise a secrets.json on your local machine.

--- a/src/Tests.IntegrationTests/appsettings.json
+++ b/src/Tests.IntegrationTests/appsettings.json
@@ -1,6 +1,8 @@
 {
-  "Bot1Url": "http://localhost:9012",
-  "Bot1ApiKey":  "testing",
-  "CentOpsUrl": "http://localhost:9014",
-  "CentOpsApiKey": "testingadmin"
+  "Bot1Url": "",
+  "Bot1ApiKey": "testing",
+  "CentOpsUrl": "",
+  "CentOpsApiKey": "",
+  "ClassifierUrl": "",
+  "DmrUrl": ""
 }

--- a/src/Tests.IntegrationTests/appsettings.json
+++ b/src/Tests.IntegrationTests/appsettings.json
@@ -3,8 +3,9 @@
   "Bot1ApiKey": "testing",
   "CentOpsUrl": "http://localhost:9014",
   "CentOpsApiKey": "testingadmin",
-  "ClassifierUrl": "http://localhost:9011",
-  "DmrUrl": "http://localhost:9010"
+  "ClassifierInternalUrl": "http://classifier",
+  "DmrInternalUrl": "http://dmr",
+  "Bot1InternalUrl": "http://bot1"
 }
 //Do not change these values.
 //Use `dotnet user-secrets init` to initialise a secrets.json on your local machine.

--- a/src/Tests.IntegrationTests/appsettings.json
+++ b/src/Tests.IntegrationTests/appsettings.json
@@ -1,6 +1,6 @@
 {
   "Bot1Url": "",
-  "Bot1ApiKey": "testing",
+  "Bot1ApiKey": "",
   "CentOpsUrl": "",
   "CentOpsApiKey": "",
   "ClassifierUrl": "",

--- a/src/Tests.IntegrationTests/appsettings.json
+++ b/src/Tests.IntegrationTests/appsettings.json
@@ -6,7 +6,7 @@
   "ClassifierInternalUrl": "http://classifier",
   "DmrInternalUrl": "http://dmr",
   "Bot1InternalUrl": "http://bot1",
-  "UseFixture": "true"
+  "GenerateTestData": "true"
 }
 //Do not change these values.
 //Use `dotnet user-secrets init` to initialise a secrets.json on your local machine.

--- a/src/Tests.IntegrationTests/appsettings.json
+++ b/src/Tests.IntegrationTests/appsettings.json
@@ -6,3 +6,7 @@
   "ClassifierUrl": "http://localhost:9011",
   "DmrUrl": "http://localhost:9010"
 }
+//Do not change these values.
+//Use `dotnet user-secrets init` to initialise a secrets.json on your local machine.
+//Use `dotnet user-secrets set "setting key" "setting value"` to configure settings to match whichever environment you are using.
+//See https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-6.0

--- a/src/Tests.IntegrationTests/appsettings.json
+++ b/src/Tests.IntegrationTests/appsettings.json
@@ -1,8 +1,8 @@
 {
-  "Bot1Url": "",
-  "Bot1ApiKey": "",
-  "CentOpsUrl": "",
-  "CentOpsApiKey": "",
-  "ClassifierUrl": "",
-  "DmrUrl": ""
+  "Bot1Url": "http://localhost:9012",
+  "Bot1ApiKey": "testing",
+  "CentOpsUrl": "http://localhost:9014",
+  "CentOpsApiKey": "testingadmin",
+  "ClassifierUrl": "http://localhost:9011",
+  "DmrUrl": "http://localhost:9010"
 }


### PR DESCRIPTION
This PR updates the integration test to work locally with settings for Azure hosted components as well as Docker Compose.

The specific changes include:
- Setting to opt in/out of using the fixture which creates its own Institution, participants etc. This is useful when running in Docker Compose but not required for Dev
- Use of .net user secrets (secrets.json) so that the settings in appsettings.json can be easily overridden with secret settings for the dev environment
- Reduction of timeout setting as the root cause of long test runs has now been addressed separately
- Updated docs for running against Azure